### PR TITLE
Added backend for logger and fixed 2 bugs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,9 @@ lazy val root = (project in file("."))
 
 val AkkaVersion = "2.6.19"
 libraryDependencies ++= Seq(
+  "org.slf4j" % "slf4j-api" % "1.7.36",
+  "ch.qos.logback" % "logback-classic" % "1.2.11",
   "com.typesafe.akka" %% "akka-actor-typed" % AkkaVersion,
   "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test
 )
+

--- a/src/main/scala/Host.scala
+++ b/src/main/scala/Host.scala
@@ -22,6 +22,9 @@ object Host {
         case CloseAuction() =>
           // Este mensaje le llega del room cuando no hay mas items, y debe cerrarse el host
           Behaviors.stopped
+        case _ =>
+          println("Ignoring message")
+          Behaviors.same
       }
     }
   }
@@ -36,23 +39,24 @@ object Host {
           // If the bet is not higher ignore it
           if (newValue <= oldValue) {
             println(f"[Host] Repeated offer with value $newValue (old value $oldValue)")
-            return auctionWithItemAndValue(item, oldValue, auctionsHosted, room, clients)
-          }
-
-          // TODO: agregar corte por tiemout
-          if (newValue > 90) {
-            // TODO: notificarle quien ganó?
-            println("[Host] We have a winner!")
-            // Last send to close all clients
-            clients.foreach(_ ! AuctionEnded())
-            room ! FinishedSession()
-            host(room, auctionsHosted, clients)
+            auctionWithItemAndValue(item, oldValue, auctionsHosted, room, clients)
           } else {
-            println(f"[Host] New offer of $newValue")
-            clients.foreach(_ ! ItemAt(newValue, context.self))
-            auctionWithItemAndValue(item, newValue, auctionsHosted, room, clients)
+            // TODO: agregar corte por tiemout
+            if (newValue > 90) {
+              // TODO: notificarle quien ganó?
+              println("[Host] We have a winner!")
+              // Last send to close all clients
+              clients.foreach(_ ! AuctionEnded())
+              // posible race condition?
+              room ! FinishedSession()
+              host(room, auctionsHosted, clients)
+            } else {
+              println(f"[Host] New offer of $newValue")
+              clients.foreach(_ ! ItemAt(newValue, context.self))
+              auctionWithItemAndValue(item, newValue, auctionsHosted, room, clients)
+            }
           }
       }
     }
-    }
+  }
 }

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,7 +1,6 @@
-import Owner.SendNextItem
 import akka.NotUsed
-import akka.actor.typed.{ActorSystem, Behavior, Terminated}
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorSystem, Behavior, Terminated}
 
 object Main {
 
@@ -15,7 +14,7 @@ object Main {
 
   def apply(): Behavior[NotUsed] =
     Behaviors.setup { context =>
-      val owner = context.spawn(Owner(itemsList, 1), "Owner")
+      val owner = context.spawn(Owner(itemsList, 2), "Owner")
       context.watch(owner)
 
       Behaviors.receiveSignal {

--- a/src/main/scala/Owner.scala
+++ b/src/main/scala/Owner.scala
@@ -66,15 +66,16 @@ object Owner {
      */
     if (notifiedRooms == rooms) {
       println("Fin del owner")
-      return Behaviors.stopped
-    }
-
-    Behaviors.receive { (context, message) =>
-      message match {
-        case SendNextItem(replyTo) =>
-          replyTo ! NoMoreItems()
-          endingProcess(notifiedRooms + 1, rooms)
+      Behaviors.stopped
+    } else {
+      Behaviors.receive { (context, message) =>
+        message match {
+          case SendNextItem(replyTo) =>
+            replyTo ! NoMoreItems()
+            endingProcess(notifiedRooms + 1, rooms)
+        }
       }
     }
+
   }
 }


### PR DESCRIPTION
"return" expression in scala actually tries to return to the context of the caller. Because the callee actor potentially executes its behaviors in a different context (basically, a different thread/thread pool), an unhandled exception is thrown, which causes each thread of execution to die (remainder: do not use "return" expression in a deferred context of execution).
The second bug was given because the FSM defined by the host received remaining auction messages from clients while it was executing its "host" state, and those messages weren't  handled (yielding a MatchError exception).